### PR TITLE
Add init tablespace size and avoid duplication of plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ When you create a plan, the broker will bind the template with the plan JSON obj
 "name" : "dev",
 "description" : "development plan",
 "metadata" : {
+"init_size" : "20M",
 "max_size" : "250M",
 "connections" : 5,
 "bullets" : ["250 megabytes of space","5 simultaneous connections"]
@@ -119,6 +120,7 @@ create tablespace ${instance.config.tablespace}
 datafile '${instance.config.tablespace}.dat' 
 size 10M 
 autoextend on 
+size ${plan.metadata.other.init_size} 
 maxsize ${plan.metadata.other.max_size} 
 extent management local 
 uniform size 64K;

--- a/src/main/java/com/pivotal/cf/broker/model/Plan.java
+++ b/src/main/java/com/pivotal/cf/broker/model/Plan.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
@@ -33,6 +34,7 @@ public class Plan {
 	
 	@JsonSerialize
 	@JsonProperty("name")
+  @Column(unique=true)
 	private String name;
 	
 	@JsonSerialize

--- a/src/main/resources/ServiceDescription.json
+++ b/src/main/resources/ServiceDescription.json
@@ -1,5 +1,5 @@
 {
-"name" : "Oracle XE",
+"name" : "Oracle-XE",
 "description" : "Oracle Express Database Service",
 "bindable" : true,
 "tags" : ["oracle","relational"],

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -2,6 +2,8 @@ oracle.host=192.168.0.55
 oracle.port=1521
 oracle.service=xe
 spring.jpa.hibernate.ddl-auto=create-drop
+# use update in order to continue with plans on app restart
+#spring.jpa.hibernate.ddl-auto=update
 broker.datasource.driverClassName=oracle.jdbc.OracleDriver
 broker.datasource.url=jdbc:oracle:thin:@${oracle.host}:${oracle.port}:${oracle.service}
 broker.datasource.username=servicebroker

--- a/src/main/resources/templates/instance/create.ftl
+++ b/src/main/resources/templates/instance/create.ftl
@@ -1,6 +1,6 @@
 create tablespace ${instance.config.tablespace} 
 datafile '${instance.config.tablespace}.dat' 
-size 10M 
+size ${plan.metadata.other.init_size}
 autoextend on 
 maxsize ${plan.metadata.other.max_size} 
 extent management local 

--- a/src/test/java/com/pivotal/cf/broker/templates/IntegrationTest.java
+++ b/src/test/java/com/pivotal/cf/broker/templates/IntegrationTest.java
@@ -33,6 +33,7 @@ public class IntegrationTest {
 		PlanMetadata metadata = new PlanMetadata();
 		metadata.setBullets(Arrays.asList("250 megabytes of space","5 simultaneous connections"));
 		metadata.getOther().put("connections", "5");
+		metadata.getOther().put("init_size","20M");
 		metadata.getOther().put("max_size","250M");
 		plan.setMetadata(metadata);
 		

--- a/src/test/java/com/pivotal/cf/broker/templates/TemplateTest.java
+++ b/src/test/java/com/pivotal/cf/broker/templates/TemplateTest.java
@@ -34,6 +34,7 @@ public class TemplateTest {
 		PlanMetadata metadata = new PlanMetadata();
 		plan.setMetadata(metadata);
 		metadata.getOther().put("connections", "5");
+		metadata.getOther().put("init_size","20M");
 		metadata.getOther().put("max_size", "500M");
 		
 		this.instance = new ServiceInstance("123", "1234", "12345", "123456", "1234567", "");


### PR DESCRIPTION
Changes:
- made the 'name' column unique in the Plan to avoid recreation/duplication of plans at restart of the service broker A
- added an initial size for the tablespace (rather than the default 10MB) just so its bigger/configurable by user. 
- when registering with marketplace, suspect the space inside "Oracle XE" appeared to cause some problem. So, changed it in the service definition template. Ignore this last part if you dont see any issues. 
